### PR TITLE
ensure the vocab loader using 'utf-8' encoding

### DIFF
--- a/codes/fine-tuning/tokenization.py
+++ b/codes/fine-tuning/tokenization.py
@@ -70,7 +70,7 @@ def load_vocab(vocab_file):
     """Loads a vocabulary file into a dictionary."""
     vocab = collections.OrderedDict()
     index = 0
-    with open(vocab_file, "r") as reader:
+    with open(vocab_file, "r", encoding="utf-8") as reader:
         while True:
             token = convert_to_unicode(reader.readline())
             if not token:


### PR DESCRIPTION
I use python 3.6.8 and found this error triggered by the vocab loader

```
File "run_classifier_single_layer.py", line 976, in <module>
    main()
  File "run_classifier_single_layer.py", line 821, in main
    vocab_file=args.vocab_file, do_lower_case=args.do_lower_case)
  File "/workspace/BERT4doc-Classification/codes/fine-tuning/tokenization.py", line 105, in __init__
    self.vocab = load_vocab(vocab_file)
  File "/workspace/BERT4doc-Classification/codes/fine-tuning/tokenization.py", line 75, in load_vocab
    token = convert_to_unicode(reader.readline())
  File "/opt/conda/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3793: ordinal not in range(128)
```

Solution: add a third parameter encoding to ensure the encoding type is 'utf-8'